### PR TITLE
Rename files to .css

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 'use strict';
 var es = require('event-stream');
 var styl = require('styl');
+var gutil = require('gulp-util');
 
 module.exports = function (options) {
 	return es.map(function (file, cb) {
 		file.contents = new Buffer(styl(file.contents.toString(), options).toString());
+		file.path = gutil.replaceExtension(file.path, '.css');
 		cb(null, file);
 	});
 };

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
   ],
   "dependencies": {
     "event-stream": "~3.0.20",
-    "styl": "~0.2.7"
+    "styl": "~0.2.7",
+    "gulp-util": "~2.1.3"
   },
   "devDependencies": {
-    "gulp-util": "~2.1.3",
     "mocha": "~1.x"
   }
 }

--- a/test.js
+++ b/test.js
@@ -6,10 +6,17 @@ var styl = require('./index');
 it('should preprocess CSS using Styl', function (cb) {
 	var stream = styl({compress: true});
 
-	stream.on('data', function (data) {
-		assert.equal(String(data.contents), '#test{width:50px;height:50px;}');
+	stream.on('data', function (newFile) {
+		assert.equal(newFile.path, '/home/gulp-styl/test/file.css');
+		assert.equal(newFile.relative, 'file.css');
+		assert.equal(String(newFile.contents), '#test{width:50px;height:50px;}');
 		cb();
 	});
 
-	stream.write(new gutil.File({contents: '#test{width:50px;height:@width;}'}));
+	stream.write(new gutil.File({
+		path: '/home/gulp-styl/test/file.styl',
+		base: '/home/gulp-styl/test/',
+		cwd: '/home/styl/',
+		contents: '#test{width:50px;height:@width;}'
+	}));
 });


### PR DESCRIPTION
Thanks for the plugin! The only problem is the compiled CSS files still have the .styl extension :)
