### PR TITLE
Compatibility fix for change in styl library

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,9 @@ module.exports = function () {
 		}
 
 		try {
-			var ret = styl(file.contents.toString());
+			var ret = styl(file.contents.toString(), options);
 			plugins.forEach(ret.use.bind(ret));
-			file.contents = new Buffer(ret.toString(options));
+			file.contents = new Buffer(ret.toString());
 			file.path = gutil.replaceExtension(file.path, '.css');
 		} catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-styl', err));


### PR DESCRIPTION
Since the [options refactoring](https://github.com/visionmedia/styl/commit/04cb3a271c7e2e59899b5d624148c4a561556ae7) in styl you can no longer pass through the whitespace significant option. This resolves that.
